### PR TITLE
fix: static loading of mnemonic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.11
 
 require (
-	github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241007185542-1a1ca1c72eb4
+	github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241118175331-3ceaf682f032
 	github.com/Layr-Labs/cerberus-api v0.0.1
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/prometheus/client_golang v1.20.3

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,3 @@
-github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241007185542-1a1ca1c72eb4/go.mod h1:7J8hptSX8cFq7KmVb+rEO5aEifj7E44c3i0afIyr4WA=
-github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241114172625-9bf17484b368 h1:BWvOmaTMU94ulNphmjdELvI/hp/gbopgFfXCmBLJZTI=
-github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241114172625-9bf17484b368/go.mod h1:7J8hptSX8cFq7KmVb+rEO5aEifj7E44c3i0afIyr4WA=
 github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241118175331-3ceaf682f032 h1:nKNJmoEB1+S1H09EsJuo8A2IXeFIg5tsGVK3UB6Qefo=
 github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241118175331-3ceaf682f032/go.mod h1:7J8hptSX8cFq7KmVb+rEO5aEifj7E44c3i0afIyr4WA=
 github.com/Layr-Labs/cerberus-api v0.0.1 h1:MSLVdxtRS1qnwLks3COnnUw/M3tjLGtbSGaLde86HRg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,8 @@
-github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241007185542-1a1ca1c72eb4 h1:0EigmyPWUGcKhbaRtuJV1XdAzlS/qwpgHf0oUhq+r7s=
 github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241007185542-1a1ca1c72eb4/go.mod h1:7J8hptSX8cFq7KmVb+rEO5aEifj7E44c3i0afIyr4WA=
+github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241114172625-9bf17484b368 h1:BWvOmaTMU94ulNphmjdELvI/hp/gbopgFfXCmBLJZTI=
+github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241114172625-9bf17484b368/go.mod h1:7J8hptSX8cFq7KmVb+rEO5aEifj7E44c3i0afIyr4WA=
+github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241118175331-3ceaf682f032 h1:nKNJmoEB1+S1H09EsJuo8A2IXeFIg5tsGVK3UB6Qefo=
+github.com/Layr-Labs/bn254-keystore-go v0.0.0-20241118175331-3ceaf682f032/go.mod h1:7J8hptSX8cFq7KmVb+rEO5aEifj7E44c3i0afIyr4WA=
 github.com/Layr-Labs/cerberus-api v0.0.1 h1:MSLVdxtRS1qnwLks3COnnUw/M3tjLGtbSGaLde86HRg=
 github.com/Layr-Labs/cerberus-api v0.0.1/go.mod h1:Lm4fhzy0S3P7GjerzuseGaBFVczsIKmEhIjcT52Hluo=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
- This enables the static loading of mnemonic files while building the docker image https://github.com/Layr-Labs/bn254-keystore-go/commit/3ceaf682f0325c0e276dc800039a53bce2c63931