### PR TITLE
chore: remove go mod tidy from docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY go.mod go.sum ./
 
-RUN go mod download && go mod tidy && go mod verify
+RUN go mod download && go mod verify
 
 COPY . .
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -4,7 +4,7 @@
 #
 #COPY go.mod go.sum ./
 #
-#RUN go mod download && go mod tidy && go mod verify
+#RUN go mod download && go mod verify
 #
 #COPY . .
 #

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,16 +1,3 @@
-#FROM golang:1.21 AS build
-#
-#WORKDIR /usr/src/app
-#
-#COPY go.mod go.sum ./
-#
-#RUN go mod download && go mod verify
-#
-#COPY . .
-#
-#ARG APP_VERSION
-#RUN go build -ldflags "-X main.version=$APP_VERSION" -v -o bin/cerberus cmd/cerberus/main.go
-
 FROM debian:latest
 COPY cerberus /cerberus
 


### PR DESCRIPTION
- `go mod tidy` is not needed for the build process and it downloads from extra deps
- remove commented code